### PR TITLE
feat(ptst): Adiciona acesso a item por indice com a sintaxe `obj[idc]`

### DIFF
--- a/gramatica/PortuscriptParser.g4
+++ b/gramatica/PortuscriptParser.g4
@@ -12,6 +12,7 @@ declaracao: declaracao_composta | declaracao_simples;
 
 declaracao_simples:
 	atribuicao
+	| expressao OPERADOR_REATRIBUICAO expressao
 	| expressao
 	| declaracao_retorne
 	| declaracao_importacao
@@ -108,10 +109,9 @@ fator: (MAIS | MENOS | NAO_BIT_A_BIT)* potencia;
 potencia: primario (POTENCIA fator)?;
 
 primario:
-	atomo (
-		PONTO primario
-		| ABRE_PARENTESES argumentos? FECHA_PARENTESES
-	)
+	primario PONTO primario
+	| primario ABRE_PARENTESES argumentos FECHA_PARENTESES
+	| primario ABRE_COLCHETES expressao FECHA_COLCHETES
 	| atomo;
 
 argumentos: argumento (VIRGULA argumento)*;

--- a/parser/ast_nodes.go
+++ b/parser/ast_nodes.go
@@ -18,7 +18,7 @@ type DeclVar struct {
 
 // Casos como `variavel += 1`, `variavel -= 1` e outros
 type Reatribuicao struct {
-	Nome      string
+	Objeto    BaseNode
 	Operador  string   // =, -=, +=, /=, //=, *= ou outros
 	Expressao BaseNode // A expressao após o sinal de igualdade
 }
@@ -123,6 +123,11 @@ type ImporteDe struct {
 	Nomes   []string
 }
 
+type Indexacao struct {
+	Objeto    BaseNode
+	Argumento BaseNode
+}
+
 func (*Programa) isExpr()            {}
 func (*DeclVar) isExpr()             {}
 func (*Reatribuicao) isExpr()        {}
@@ -148,3 +153,4 @@ func (*ContinueNode) isExpr()        {}
 func (*TuplaLiteral) isExpr()        {}
 func (*ListaLiteral) isExpr()        {}
 func (*ImporteDe) isExpr()           {}
+func (*Indexacao) isExpr()           {}

--- a/ptst/interfaces.go
+++ b/ptst/interfaces.go
@@ -155,3 +155,11 @@ type I_iterador interface {
 type I__tamanho__ interface {
 	M__tamanho__() (Objeto, error)
 }
+
+type I__obtem_item__ interface {
+	M__obtem_item__(obj Objeto) (Objeto, error)
+}
+
+type I__define_item__ interface {
+	M__define_item__(chave, valor Objeto) (Objeto, error)
+}

--- a/ptst/internos.go
+++ b/ptst/internos.go
@@ -51,7 +51,7 @@ func NomeAtributo(obj Objeto) (string, error) {
 	return "", NewErroF(AtributoErro, "O nome do atributo deve ser do tipo texto, não '%s'", obj.Tipo().Nome)
 }
 
-func ObtemItemS(inst Objeto, nome string) (Objeto, error) {
+func ObtemAtributoS(inst Objeto, nome string) (Objeto, error) {
 	if I, ok := inst.(I__obtem_attributo__); ok {
 		return I.M__obtem_attributo__(nome)
 	}
@@ -83,7 +83,6 @@ func ObtemItemS(inst Objeto, nome string) (Objeto, error) {
 		return obj, nil
 	}
 
-	// FIXME: adicionar a capacidade de chamar o método __obtem_item__ e __obtem__
 	return nil, NewErroF(AtributoErro, "O atributo '%s' não existe no tipo '%s'", nome, inst.Tipo().Nome)
 }
 
@@ -120,6 +119,7 @@ func Iter(obj Objeto) (Objeto, error) {
 	return nil, NewErroF(TipagemErro, "O objeto do tipo '%s' não implementa a interface do iterador", obj.Tipo().Nome)
 }
 
+// FIXME: esta não é a melhor assinatura possível
 func InstanciaDe(obj Objeto, tipos any) (Booleano, error) {
 	switch tipo_tupla := tipos.(type) {
 	case Tupla:
@@ -136,4 +136,20 @@ func InstanciaDe(obj Objeto, tipos any) (Booleano, error) {
 		// FIXME: verificar se realmente é um tipo usável
 		return obj.Tipo() == tipos.(*Tipo), nil
 	}
+}
+
+func ObtemItem(inst, arg Objeto) (Objeto, error) {
+	if I, ok := inst.(I__obtem_item__); ok {
+		return I.M__obtem_item__(arg)
+	}
+	
+	return nil, NewErroF(TipagemErro, "O tipo '%s' não suporta o uso de indices", inst.Tipo().Nome)
+}
+
+func DefineItem(inst, chave, valor Objeto) (Objeto, error) {
+	if I, ok := inst.(I__define_item__); ok {
+		return I.M__define_item__(chave, valor)
+	}
+	
+	return nil, NewErroF(TipagemErro, "O tipo '%s' não suporta a atribuição por indice", inst.Tipo().Nome)
 }

--- a/ptst/lista.go
+++ b/ptst/lista.go
@@ -25,9 +25,23 @@ func (l *Lista) M__tamanho__() (Objeto, error) {
 	return l.Itens.M__tamanho__()
 }
 
+func (l *Lista) M__obtem_item__(obj Objeto) (Objeto, error) {
+	return l.Itens.ObtemItem(obj, "Lista")
+}
+
+func (l *Lista) M__define_item__(chave, valor Objeto) (Objeto, error) {
+	if _, err := l.Itens.DefineItem(chave, valor, l.Tipo().Nome); err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
 var _ I__iter__ = (*Lista)(nil)
 var _ I__texto__ = (*Lista)(nil)
 var _ I__tamanho__ = (*Lista)(nil)
+var _ I__obtem_item__ = (*Lista)(nil)
+var _ I__define_item__ = (*Lista)(nil)
 
 func (l *Lista) Adiciona(item Objeto) (Objeto, error) {
 	l.Itens = append(l.Itens, item)

--- a/ptst/tupla.go
+++ b/ptst/tupla.go
@@ -12,7 +12,7 @@ func (t Tupla) Tipo() *Tipo {
 }
 
 func (t Tupla) GRepr(inicio, fim string) (Objeto, error) {
-	junta, err := ObtemItemS(Texto(","), "junta")
+	junta, err := ObtemAtributoS(Texto(","), "junta")
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +37,33 @@ func (t Tupla) M__tamanho__() (Objeto, error) {
 	return Inteiro(len(t)), nil
 }
 
+func (t Tupla) ObtemItem(i Objeto, nomeTipo string) (Objeto, error) {
+	if I, ok := i.(Inteiro); ok {
+		return t[I], nil
+	}
+
+	return nil, NewErroF(TipagemErro, "O tipo '%s' não é aceito para indexação no tipo '%s'. Use um 'Inteiro'.", i.Tipo().Nome, nomeTipo)
+}
+
+func (t Tupla) DefineItem(chave, valor Objeto, nomeTipo string) (Objeto, error) {
+	if I, ok := chave.(Inteiro); ok {
+		t[I] = valor
+		return t, nil
+	}
+
+	return nil, NewErroF(TipagemErro, "O tipo '%s' não é aceito para indexação no tipo '%s'. Use um 'Inteiro'.", chave.Tipo().Nome, nomeTipo)
+}
+
+func (t Tupla) M__obtem_item__(obj Objeto) (Objeto, error) {
+	return t.ObtemItem(obj, t.Tipo().Nome)
+}
+
+func (t Tupla) M__define_item__(chave, valor Objeto) (Objeto, error) {
+	return t.DefineItem(chave, valor, t.Tipo().Nome)
+}
+
 var _ I__iter__ = Tupla(nil)
 var _ I__texto__ = Tupla(nil)
 var _ I__tamanho__ = Tupla(nil)
+var _ I__obtem_item__ = Tupla(nil)
+var _ I__define_item__ = Tupla(nil)

--- a/stdlib/colorize/imprimac.go
+++ b/stdlib/colorize/imprimac.go
@@ -18,7 +18,7 @@ func met_color_imprimac(inst ptst.Objeto, args ptst.Tupla) (ptst.Objeto, error) 
 	var junta, textoObj ptst.Objeto
 	var err error
 
-	if junta, err = ptst.ObtemItemS(ptst.Texto(""), "junta"); err != nil {
+	if junta, err = ptst.ObtemAtributoS(ptst.Texto(""), "junta"); err != nil {
 		return nil, err
 	}
 	

--- a/stdlib/embutidos/imprima.go
+++ b/stdlib/embutidos/imprima.go
@@ -12,7 +12,7 @@ func met_emb_imprima(mod ptst.Objeto, args ptst.Tupla) (ptst.Objeto, error) {
 		separador = ptst.Texto(" ")
 	)
 
-	junta, err := ptst.ObtemItemS(separador, "junta")
+	junta, err := ptst.ObtemAtributoS(separador, "junta")
 
 	if err != nil {
 		return nil, err

--- a/tests/parser_test/condicionais_test.go
+++ b/tests/parser_test/condicionais_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/natanfeitosa/portuscript/parser"
@@ -10,7 +11,7 @@ func TestExpresaoSeSemCorpo(t *testing.T) {
 	esperada := &parser.Programa{}
 	esperada.Declaracoes = []parser.BaseNode{
 		&parser.ExpressaoSe{
-			Condicao: &parser.ConstanteLiteral{Valor: "Verdadeiro"},
+			Condicao: &parser.Identificador{Nome: "Verdadeiro"},
 			Corpo: &parser.Bloco{},
 		},
 	}
@@ -20,6 +21,8 @@ func TestExpresaoSeSemCorpo(t *testing.T) {
 	`
 
 	err, ok := createParserAndCompare(code, esperada)
+	
+	fmt.Println(err, ok)
 
 	if !ok {
 		t.Error(err)
@@ -30,7 +33,7 @@ func TestExpresaoSe(t *testing.T) {
 	esperada := &parser.Programa{}
 	esperada.Declaracoes = []parser.BaseNode{
 		&parser.ExpressaoSe{
-			Condicao: &parser.ConstanteLiteral{Valor: "Verdadeiro"},
+			Condicao: &parser.Identificador{Nome: "Verdadeiro"},
 			Corpo: &parser.Bloco{
 				Declaracoes: []parser.BaseNode{
 					&parser.ChamadaFuncao{

--- a/tests/parser_test/variaveis_test.go
+++ b/tests/parser_test/variaveis_test.go
@@ -48,14 +48,14 @@ func TestSimplesAtribuicaoConstante(t *testing.T) {
 
 func TestSimplesReatribuicao(t *testing.T) {
 	esperada := &parser.Programa{}
-	
+
 	inteiro := &parser.InteiroLiteral{Valor: "1"}
 
 	esperada.Declaracoes = []parser.BaseNode{
-		&parser.Reatribuicao{Nome: "variavel", Operador: "+=", Expressao: inteiro},
-		&parser.Reatribuicao{Nome: "variavel", Operador: "-=", Expressao: inteiro},
-		&parser.Reatribuicao{Nome: "variavel", Operador: "/=", Expressao: inteiro},
-		&parser.Reatribuicao{Nome: "variavel", Operador: "*=", Expressao: inteiro},
+		&parser.Reatribuicao{Objeto: &parser.Identificador{Nome: "variavel"}, Operador: "+=", Expressao: inteiro},
+		&parser.Reatribuicao{Objeto: &parser.Identificador{Nome: "variavel"}, Operador: "-=", Expressao: inteiro},
+		&parser.Reatribuicao{Objeto: &parser.Identificador{Nome: "variavel"}, Operador: "/=", Expressao: inteiro},
+		&parser.Reatribuicao{Objeto: &parser.Identificador{Nome: "variavel"}, Operador: "*=", Expressao: inteiro},
 	}
 
 	code := `


### PR DESCRIPTION
Adiciona sintaxe para manipulação de objetos por índice, como por exemplo:

```ptst
var lista = [1, 2, 3, 4];
imprima(lista[0]) # 1
```

```ptst
var lista = [1, 2, 3, 4];
lista[0] += 1;
imprima(lista[0]) # 2
```