### PR TITLE
feat(ptst): método para ser usado com operador `em`

### DIFF
--- a/ptst/lista.go
+++ b/ptst/lista.go
@@ -37,11 +37,16 @@ func (l *Lista) M__define_item__(chave, valor Objeto) (Objeto, error) {
 	return l, nil
 }
 
+func (l *Lista) M__contem__(obj Objeto) (Objeto, error) {
+	return l.Itens.M__contem__(obj)
+}
+
 var _ I__iter__ = (*Lista)(nil)
 var _ I__texto__ = (*Lista)(nil)
 var _ I__tamanho__ = (*Lista)(nil)
 var _ I__obtem_item__ = (*Lista)(nil)
 var _ I__define_item__ = (*Lista)(nil)
+var _ I__contem__ = (*Lista)(nil)
 
 func (l *Lista) Adiciona(item Objeto) (Objeto, error) {
 	l.Itens = append(l.Itens, item)
@@ -84,7 +89,7 @@ func (l *Lista) Pop(indice Inteiro) (Objeto, error) {
 
 		novaTupla = append(novaTupla, item)
 	}
-	
+
 	l.Itens = novaTupla
 	return removido, nil
 }

--- a/ptst/texto.go
+++ b/ptst/texto.go
@@ -117,9 +117,17 @@ func (t Texto) String() string {
 	return string(t)
 }
 
-// func (t Texto) ObtemMapa() Mapa {
-// 	return t.Tipo().Mapa
-// }
+func (t Texto) M__contem__(obj Objeto) (Objeto, error) {
+	if other, err := NewTexto(obj); err != nil {
+		return nil, err
+	} else if other != nil {
+		if strings.Contains(string(t), string(other.(Texto))) {
+			return Verdadeiro, nil
+		}
+	}
+
+	return Falso, nil
+}
 
 var _ I__texto__ = (*Texto)(nil)
 var _ I__bytes__ = (*Texto)(nil)
@@ -136,6 +144,8 @@ var _ I__multiplica__ = (*Texto)(nil)
 // var _ I__divide__ = (*Texto)(nil)
 // var _ I_Mapa = (*Texto)(nil)
 var _ I__tamanho__ = (*Texto)(nil)
+
+var _ I__contem__ = (*Texto)(nil)
 
 func init() {
 	TipoTexto.Mapa["junta"] = NewMetodoOuPanic("junta", func(inst Objeto, iter Objeto) (Objeto, error) {

--- a/ptst/tupla.go
+++ b/ptst/tupla.go
@@ -62,8 +62,19 @@ func (t Tupla) M__define_item__(chave, valor Objeto) (Objeto, error) {
 	return t.DefineItem(chave, valor, t.Tipo().Nome)
 }
 
+func (t Tupla) M__contem__(obj Objeto) (Objeto, error) {
+	for _, item := range t {
+		if igual, _ := Igual(item, obj); igual == Verdadeiro {
+			return Verdadeiro, nil
+		}
+	}
+
+	return Falso, nil
+}
+
 var _ I__iter__ = Tupla(nil)
 var _ I__texto__ = Tupla(nil)
 var _ I__tamanho__ = Tupla(nil)
 var _ I__obtem_item__ = Tupla(nil)
 var _ I__define_item__ = Tupla(nil)
+var _ I__contem__ = Tupla(nil)


### PR DESCRIPTION
Agora listas, tuplas e textos podem ser usados a esquerda de uma operação `op em op2` como `(1 em [1, 2, 3]) == Verdadeiro`